### PR TITLE
Feature/hgi 9773: classify invalid credentials properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,5 @@ dmypy.json
 
 docker-compose.yml
 .vscode/
+
+**/.DS_Store

--- a/tap_woocommerce/client.py
+++ b/tap_woocommerce/client.py
@@ -14,7 +14,7 @@ from random_user_agent.params import SoftwareName, OperatingSystem, Popularity
 from hotglue_singer_sdk.authenticators import BasicAuthenticator
 from hotglue_singer_sdk.helpers.jsonpath import extract_jsonpath
 from hotglue_singer_sdk.streams import RESTStream
-from hotglue_singer_sdk.exceptions import FatalAPIError, RetriableAPIError
+from hotglue_singer_sdk.exceptions import RetriableAPIError
 from hotglue_singer_sdk.tap_base import InvalidCredentialsError
 from http.client import RemoteDisconnected
 from requests.exceptions import ChunkedEncodingError

--- a/tap_woocommerce/client.py
+++ b/tap_woocommerce/client.py
@@ -21,6 +21,8 @@ from requests.exceptions import ChunkedEncodingError
 
 logging.getLogger("backoff").setLevel(logging.CRITICAL)
 
+class RetriableInvalidCredentialsError(RetriableAPIError, InvalidCredentialsError):
+    pass
 
 class WooCommerceStream(RESTStream):
     """WooCommerce stream class."""
@@ -201,14 +203,14 @@ class WooCommerceStream(RESTStream):
                 f"Full request url: {response.request.url} "
                 f"Response: {body}"
             )
-            raise RetriableAPIError(msg)
+            raise RetriableInvalidCredentialsError(msg)
         elif 400 <= response.status_code < 500:
             msg = (
                 f"{response.status_code} Client Error: "
                 f"{response.reason} for path: {self.path} "
                 f"Response: {body}"
             )
-            raise FatalAPIError(msg)
+            raise InvalidCredentialsError(msg)
         try:
             response.json()
         except:

--- a/tap_woocommerce/tap.py
+++ b/tap_woocommerce/tap.py
@@ -34,7 +34,7 @@ STREAM_TYPES = [
 class TapWooCommerce(Tap):
     """WooCommerce tap class."""
     name = "tap-woocommerce"
-    alerting_level = AlertingLevel.WARNING
+    alerting_level = AlertingLevel.ERROR
 
     config_jsonschema = th.PropertiesList(
         th.Property("consumer_key", th.StringType, required=True),


### PR DESCRIPTION
Modified client.py, now at the retry cases (line 199) we handle it properly when the max_retries is achieved;
400s errors treated as Invalid Credentils Error
Modify the AlertingLevel (tap.py) to get new errors back to Slack;